### PR TITLE
Add solution to Exercise1.13

### DIFF
--- a/ch1/13.scm
+++ b/ch1/13.scm
@@ -1,0 +1,18 @@
+(load "../libs/init.scm")
+
+(define subst-in-s-exp
+  (lambda (new old sexp)
+          (if (symbol? sexp)
+            (if (eqv? sexp old) new sexp)
+            (subst new old sexp))))
+
+(define subst
+  (lambda (new old slist)
+          (if (null? slist)
+            '()
+            (map (lambda (item) (subst-in-s-exp new old item)) slist))))
+
+(equal?? (subst 'a 'b '(a b c d e)) '(a a c d e))
+(equal?? (subst 'a 'b '(b)) '(a))
+(equal?? (subst 'a 'b '(b b b)) '(a a a))
+(equal?? (subst 's 'a '((a b) c d s)) '((s b) c d s))


### PR DESCRIPTION
I add solution to Exercise1.13
The content of to Exercise1.13 is:

> "In our example, we began by eliminating the Kleene star in the
>grammar for S-list. Write subst following the original grammar by using map"