### PR TITLE
Update 26.scm

### DIFF
--- a/ch2/26.scm
+++ b/ch2/26.scm
@@ -18,7 +18,7 @@
       (or (null? val)
           (and (pair? val)
                (pred (car val))
-               (list-of (cdr val)))))))
+               ((list-of pred) (cdr val)))))))
 
 (define aux-mark-leaves-with-red-depth
   (lambda (rbt acc)


### PR DESCRIPTION
`(list-of (cdr val))` returns a lambda function, which will make the `and` expression is always `#t`